### PR TITLE
Use more universal shebang for locating Python interpreter

### DIFF
--- a/pixel2svg.py
+++ b/pixel2svg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """pixel2svg - Convert pixel art to SVG
 


### PR DESCRIPTION
Changes the shebang line from `#!/usr/bin/python` to `#!/usr/bin/env python`. This allows the script to be used on platforms where the Python interpreter might be located on a path other than `/usr/bin`, such as FreeBSD where it is located in `/usr/local/bin`.

P.S. Thank you for updating/working on this script. It works much better than Inkscape.